### PR TITLE
Adjust footer colors for light theme

### DIFF
--- a/footer.css
+++ b/footer.css
@@ -1,15 +1,15 @@
-    .site-footer{--footer-start:#1a2a88; --footer-end:#121a66; background:linear-gradient(180deg, var(--footer-start) 0%, var(--footer-end) 100%); color:var(--fg)}
+    .site-footer{--footer-start:#1a2a88; --footer-end:#121a66; --footer-fg:#f3f6ff; background:linear-gradient(180deg, var(--footer-start) 0%, var(--footer-end) 100%); color:var(--footer-fg)}
     .site-footer a{text-decoration:none; color:inherit}
     .footer-top{padding:32px 0 8px}
     .footer-row{display:flex; align-items:center; justify-content:space-between; gap:16px; flex-wrap:wrap}
     .footer-brand .name{font-weight:800; font-size:20px; color:inherit}
     .footer-brand .tag{color:var(--muted); margin-top:6px}
     .footer-icons{display:flex; gap:10px}
-    .icon-btn{display:inline-flex; align-items:center; justify-content:center; width:40px; height:40px; border-radius:10px; background:color-mix(in srgb, var(--fg) 10%, transparent); border:1px solid color-mix(in srgb, var(--fg) 22%, transparent); box-shadow:0 10px 24px rgba(2,6,23,.35); transition:transform .15s ease, background .2s ease; color:var(--fg)}
-    .icon-btn:hover{background:color-mix(in srgb, var(--fg) 16%, transparent); transform:translateY(-1px)}
+    .icon-btn{display:inline-flex; align-items:center; justify-content:center; width:40px; height:40px; border-radius:10px; background:color-mix(in srgb, var(--footer-fg) 12%, transparent); border:1px solid color-mix(in srgb, var(--footer-fg) 26%, transparent); box-shadow:0 10px 24px rgba(2,6,23,.35); transition:transform .15s ease, background .2s ease; color:var(--footer-fg)}
+    .icon-btn:hover{background:color-mix(in srgb, var(--footer-fg) 18%, transparent); transform:translateY(-1px)}
     .footer-divider{border:0; height:1px; background:var(--border); margin:14px 0 10px}
-    .footer-bottom{text-align:center; padding:12px 0 18px; color:var(--fg); font-size:14px}
+    .footer-bottom{text-align:center; padding:12px 0 18px; color:inherit; font-size:14px}
 
     /* Responsive */
     /* Dark footer palette override */
-    :root[data-theme="dark"] .site-footer{--footer-start: color-mix(in srgb, var(--bg) 6%, #0f172a); --footer-end: color-mix(in srgb, var(--bg) 0%, #0b1220); color:var(--fg);}
+    :root[data-theme="dark"] .site-footer{--footer-start: color-mix(in srgb, var(--bg) 6%, #0f172a); --footer-end: color-mix(in srgb, var(--bg) 0%, #0b1220); --footer-fg:var(--fg); color:var(--fg);}


### PR DESCRIPTION
## Summary
- update the footer to use a lighter foreground color in light mode for better contrast with the blue gradient
- align the footer icon button styling with the new footer foreground color variable

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d7f93e4c88832383de94ab58b95a93