### PR TITLE
Fix carousel spacing and arrow placement

### DIFF
--- a/carousel.css
+++ b/carousel.css
@@ -1,6 +1,6 @@
-/* Carousel (peek + centered arrows) */
-/* :root{ --peek: clamp(16px, 3vw, 36px); } */
-:root { --peek: clamp(24px, 6vw, 72px); }
+/* Carousel (full-bleed slides with centered arrows) */
+
+:root { --peek: 0px; }
 
 #projects .reveal { opacity: 1 !important; visibility: visible !important; transform: none !important; }
 
@@ -42,8 +42,8 @@
 .carousel figure{
   position:relative;
   aspect-ratio:16/9;      /* 56.25% */
-  margin:0 var(--peek);
-  min-width:calc(100% - (var(--peek) * 2));
+  margin:0;
+  min-width:100%;
   border-radius:12px;
   overflow:hidden;
 }
@@ -54,12 +54,13 @@
 .carousel img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; display:block; }
 
 .carousel .nav{
-  position:absolute; inset:0; display:flex; align-items:center; justify-content:space-between;
+  position:absolute; inset:0; padding:0 16px;
+  display:flex; align-items:center; justify-content:space-between;
   pointer-events:none; z-index:3; /* arrows vertically centered */
 }
 .carousel .nav button{
   pointer-events:auto; display:inline-flex; align-items:center; justify-content:center;
-  width:46px; height:46px; margin:0 8px; border-radius:999px;
+  width:46px; height:46px; margin:0; border-radius:999px;
   border:1px solid var(--border);
   background:color-mix(in srgb, var(--bg) 55%, transparent);
   color:var(--fg); box-shadow:0 6px 18px rgba(2,6,23,.15);
@@ -80,5 +81,5 @@
 
 
 @media (max-width: 640px){
-  :root { --peek: 16px; } /* tighter on small screens */
+  :root { --peek: 0px; }
 }


### PR DESCRIPTION
## Summary
- remove the slide side gutters so carousel images sit flush inside the frame
- move the carousel navigation buttons inside the image area for better alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fdd411dc8323bfde94582f2c1765