### PR TITLE
Fix clipping of hero title descender

### DIFF
--- a/main.css
+++ b/main.css
@@ -77,7 +77,7 @@
     .btn-lg{padding:16px 26px; font-size:18px}
 
     /* Headline font */
-    .hero h1{font-family:'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji"; font-weight:600; letter-spacing:-0.005em; font-size:clamp(44px, 7vw, 84px); line-height:1.02; font-synthesis:none}
+    .hero h1{font-family:'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji"; font-weight:600; letter-spacing:-0.005em; font-size:clamp(44px, 7vw, 84px); line-height:1.08; font-synthesis:none}
 
     /* Animated gradient word in hero */
     .btn svg{width:20px; height:20px}


### PR DESCRIPTION
## Summary
- slightly increase the hero title line height so the letter "y" renders fully

## Testing
- Manual QA: Viewed the hero section to confirm the descender in "reality" is no longer clipped


------
https://chatgpt.com/codex/tasks/task_e_68d81254ee448323b395614b7d727314