### PR TITLE
Adjust hero headline line height

### DIFF
--- a/main.css
+++ b/main.css
@@ -77,7 +77,7 @@
     .btn-lg{padding:16px 26px; font-size:18px}
 
     /* Headline font */
-    .hero h1{font-family:'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji"; font-weight:600; letter-spacing:-0.005em; font-size:clamp(44px, 7vw, 84px); line-height:1.08; font-synthesis:none}
+    .hero h1{font-family:'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji"; font-weight:600; letter-spacing:-0.005em; font-size:clamp(44px, 7vw, 84px); line-height:1.12; font-synthesis:none}
 
     /* Animated gradient word in hero */
     .btn svg{width:20px; height:20px}


### PR DESCRIPTION
## Summary
- loosen the hero headline line height so the gradient text no longer appears clipped at the bottom

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d8140f8288832384ee10c6b20b4188