### PR TITLE
Add scroll reveal animation to featured projects section

### DIFF
--- a/carousel.css
+++ b/carousel.css
@@ -2,9 +2,6 @@
 
 :root { --peek: 0px; }
 
-#projects .reveal { opacity: 1 !important; visibility: visible !important; transform: none !important; }
-
-
 .carousel{
   position:relative; margin-top:14px; border-radius:16px; overflow:hidden;
   background:var(--card); border:1px solid var(--border); box-shadow:var(--shadow);

--- a/index.html
+++ b/index.html
@@ -447,7 +447,7 @@
         });
       }, { rootMargin: '0px 0px -12% 0px', threshold: 0.06 });
 
-      var targets = document.querySelectorAll('#about .section-title, #about .section-sub, #about .chip, #about .pillar, #projects .section-title, #projects .section-sub, #projects .project, #contact .form-card');
+      var targets = document.querySelectorAll('#about .section-title, #about .section-sub, #about .chip, #about .pillar, #projects .section-title, #projects .section-sub, #projects .project, #projects .project-case, #contact .form-card');
       targets.forEach(function(el, i){
         if(!el.classList.contains('reveal')) el.classList.add('reveal','up');
         el.style.transitionDelay = (i % 6) * 60 + 'ms';


### PR DESCRIPTION
## Summary
- enable the scroll reveal observer to watch featured project cards
- remove CSS override that kept project reveals visible at all times so they animate like other sections

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8187e9dcc83238a13b3224b297984