### PR TITLE
Fix contact form label spacing and color tweaks

### DIFF
--- a/contact.css
+++ b/contact.css
@@ -1,5 +1,5 @@
     form{display:grid; gap:12px}
-    label{font-weight:600}
+    label{font-weight:600; display:inline-block; margin-bottom:6px}
     input, textarea{width:100%; padding:16px 14px; min-height:48px; border-radius:12px; background:var(--card); color:var(--fg); border:1px solid var(--border); box-shadow:0 1px 0 rgba(2,6,23,.04)}
     textarea{min-height:140px; padding:18px 14px}
     textarea{min-height:140px; padding:18px 14px}

--- a/footer.css
+++ b/footer.css
@@ -3,7 +3,7 @@
     .footer-top{padding:32px 0 8px}
     .footer-row{display:flex; align-items:center; justify-content:space-between; gap:16px; flex-wrap:wrap}
     .footer-brand .name{font-weight:800; font-size:20px; color:inherit}
-    .footer-brand .tag{color:var(--muted); margin-top:6px}
+    .footer-brand .tag{color:var(--footer-fg); margin-top:6px}
     .footer-icons{display:flex; gap:10px}
     .icon-btn{display:inline-flex; align-items:center; justify-content:center; width:40px; height:40px; border-radius:10px; background:color-mix(in srgb, var(--footer-fg) 12%, transparent); border:1px solid color-mix(in srgb, var(--footer-fg) 26%, transparent); box-shadow:0 10px 24px rgba(2,6,23,.35); transition:transform .15s ease, background .2s ease; color:var(--footer-fg)}
     .icon-btn:hover{background:color-mix(in srgb, var(--footer-fg) 18%, transparent); transform:translateY(-1px)}

--- a/main.css
+++ b/main.css
@@ -180,7 +180,7 @@
     .about-lead{max-width:920px; font-size:clamp(16px,1.5vw,20px)}
     .about-services{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px 14px; margin:18px 0 30px}
     .chip{display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 30%, transparent); font-weight:600}
-    .chip svg{width:16px; height:16px; opacity:.9}
+    .chip svg{width:16px; height:16px; opacity:.9; color:#4ade80}
     .grid.cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}
     .about-pillars{margin-top:8px}
     .pillar{text-align:center; padding:8px}


### PR DESCRIPTION
## Summary
- add spacing between contact form labels and their inputs for better focus state clarity
- update the footer tagline to use the footer foreground color so it matches the surrounding text
- tint the About section checkmark icons with a light green accent

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d81ce56f4c83238b0fdc4f63326166