### PR TITLE
Improve mobile hero spacing and header responsiveness

### DIFF
--- a/media-queries.css
+++ b/media-queries.css
@@ -1,35 +1,41 @@
-    @media (max-width: 900px){
-      .hero .container{grid-template-columns:1fr}
-      .grid.cols-3{grid-template-columns:1fr 1fr}
-      .grid.cols-4{grid-template-columns:1fr 1fr}
-      .about-services{grid-template-columns:1fr}
-    }
-      .grid.cols-3{grid-template-columns:1fr 1fr}
-    
-    @media (max-width: 640px){
-      nav ul{display:none}
-      .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
-      .form-row{grid-template-columns:1fr}
-      .hero-cta{flex-direction:column}
-      .hero-cta .btn{width:100%}
-      .ring{width:112px; height:112px}
-      .about-services{grid-template-columns:1fr}
-      .footer-row{flex-direction:column; align-items:flex-start; gap:12px}
-    }
-      .grid.cols-2, .grid.cols-3{grid-template-columns:1fr}
-      .form-row{grid-template-columns:1fr}
-    
+@media (max-width: 900px){
+  .hero .container{grid-template-columns:1fr}
+  .grid.cols-3{grid-template-columns:1fr 1fr}
+  .grid.cols-4{grid-template-columns:1fr 1fr}
+  .about-services{grid-template-columns:1fr}
+}
 
-    /* Hero size overrides (mobile) */
-    @media (max-width: 640px){
-      .hero{min-height:auto}
-      .hero .container{padding:72px 20px}
-      .network-card{min-height:320px}
-    }
-    @media (max-width: 480px){
-      .hero .container{padding:64px 16px}
-      .ring{width:96px; height:96px}
-      .lead{font-size:16px}
-      .btn-lg{font-size:16px; padding:14px 20px}
-      .footer-bottom{font-size:13px}
-    }
+@media (max-width: 640px){
+  header{border-bottom-width:0}
+  .nav{display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:10px 14px; padding:12px 0}
+  .brand{font-size:16px}
+  .theme-toggle{margin-right:0; width:36px; height:36px; justify-self:end}
+  .cta{padding:10px 16px; font-size:15px; justify-self:end}
+  nav ul{display:none}
+  .nav nav{display:none}
+  .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
+  .form-row{grid-template-columns:1fr}
+  .hero-cta{flex-direction:column}
+  .hero-cta .btn{width:100%}
+  .ring{width:112px; height:112px}
+  .about-services{grid-template-columns:1fr}
+  .footer-row{flex-direction:column; align-items:flex-start; gap:12px}
+}
+
+
+/* Hero size overrides (mobile) */
+@media (max-width: 640px){
+  .hero{min-height:auto}
+  .hero .container{padding:56px 20px}
+  .network-card{min-height:320px}
+  .cta{width:max-content}
+}
+@media (max-width: 480px){
+  .nav{grid-template-columns:auto auto; grid-template-rows:auto auto}
+  .cta{grid-column:1 / -1; justify-self:stretch; width:100%; text-align:center}
+  .hero .container{padding:48px 16px}
+  .ring{width:96px; height:96px}
+  .lead{font-size:16px}
+  .btn-lg{font-size:16px; padding:14px 20px}
+  .footer-bottom{font-size:13px}
+}


### PR DESCRIPTION
## Summary
- switch the mobile header layout to a compact grid that tucks the brand, theme toggle, and CTA without overflowing
- trim hero spacing and adjust CTA sizing on small screens to reduce the gap beneath the header

## Testing
- None


------
https://chatgpt.com/codex/tasks/task_e_68d828c9d63083239a6cdd1e6f96ad83