### PR TITLE
Add mobile navigation drawer and adjust hero spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,18 +37,24 @@
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
       <div class="brand"><img src="assets/uplora-logo.png" alt="Uplora logo" class="logo" /> Uplora</div>
-      <nav>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="visually-hidden">Toggle navigation</span>
+        <svg class="menu-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="close-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <nav id="primary-nav">
         <ul>
           <li><a href="#about">About</a></li>
           <li><a href="#projects">Projects</a></li>
           <li><a href="#contact">Contact</a></li>
         </ul>
+        <a class="cta mobile-cta" href="#contact">Work with us</a>
       </nav>
       <button class="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false">
         <svg class="sun" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="1.8"/><path d="M12 2v3M12 19v3M4.6 4.6l2.1 2.1M17.3 17.3l2.1 2.1M2 12h3M19 12h3M4.6 19.4l2.1-2.1M17.3 6.7l2.1-2.1" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         <svg class="moon" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M21 12.3A9 9 0 1 1 11.7 3a7 7 0 1 0 9.3 9.3Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
-      <a class="cta" href="#contact">Work with us</a>
+      <a class="cta desktop-cta" href="#contact">Work with us</a>
     </div>
   </header>
 
@@ -414,6 +420,66 @@
       });
       sync();
     }
+  })();
+</script>
+
+<script>
+  // Mobile navigation toggle
+  (function(){
+    var navContainer = document.querySelector('.nav');
+    var menuToggle = document.querySelector('.menu-toggle');
+    if(!navContainer || !menuToggle) return;
+    var menu = document.getElementById(menuToggle.getAttribute('aria-controls'));
+    if(!menu) return;
+    var firstLink = menu.querySelector('a');
+    var previousOverflow = '';
+
+    function closeMenu(){
+      navContainer.classList.remove('menu-open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = previousOverflow;
+      navContainer.style.removeProperty('--nav-height');
+    }
+
+    function openMenu(){
+      var rect = navContainer.getBoundingClientRect();
+      navContainer.style.setProperty('--nav-height', rect.height + 'px');
+      previousOverflow = document.body.style.overflow || '';
+      document.body.style.overflow = 'hidden';
+      navContainer.classList.add('menu-open');
+      menuToggle.setAttribute('aria-expanded', 'true');
+      if(firstLink) firstLink.focus();
+    }
+
+    menuToggle.addEventListener('click', function(){
+      var isOpen = navContainer.classList.contains('menu-open');
+      if(isOpen) closeMenu(); else openMenu();
+    });
+
+    menu.addEventListener('click', function(evt){
+      var target = evt.target;
+      if(target && target.closest('a')) closeMenu();
+    });
+
+    document.addEventListener('keydown', function(evt){
+      if(evt.key === 'Escape' && navContainer.classList.contains('menu-open')){
+        evt.preventDefault();
+        closeMenu();
+        menuToggle.focus();
+      }
+    });
+
+    document.addEventListener('click', function(evt){
+      if(!navContainer.classList.contains('menu-open')) return;
+      if(menu.contains(evt.target) || menuToggle.contains(evt.target)) return;
+      closeMenu();
+    });
+
+    window.addEventListener('resize', function(){
+      if(window.innerWidth > 640 && navContainer.classList.contains('menu-open')){
+        closeMenu();
+      }
+    });
   })();
 </script>
 

--- a/main.css
+++ b/main.css
@@ -42,7 +42,7 @@
 
     /* Header */
     header{position:sticky; top:0; z-index:50; backdrop-filter:saturate(140%) blur(10px); background:color-mix(in srgb, var(--bg) 70%, transparent); border-bottom:1px solid var(--border)}
-    .nav{display:flex; align-items:center; justify-content:space-between; padding:14px 0}
+    .nav{display:flex; align-items:center; justify-content:space-between; padding:14px 0; position:relative}
     .brand{display:flex; align-items:center; gap:12px; font-weight:700; letter-spacing:.2px; font-size:18px; color:var(--accent)}
     .brand .logo{width:40px; height:auto; display:block; filter:drop-shadow(0 6px 18px rgba(15,76,129,.25))}
     :root[data-theme="dark"] .brand{color:var(--accent-2)}
@@ -51,6 +51,14 @@
     nav a:hover, nav a:focus-visible{background:color-mix(in srgb, var(--accent-2) 18%, transparent); border-color:color-mix(in srgb, var(--accent) 26%, transparent); outline:none}
     .cta{padding:8px 14px; border-radius:12px; background:linear-gradient(135deg, var(--accent), var(--accent-2)); color:white; text-decoration:none; font-weight:600; border:1px solid color-mix(in srgb, var(--accent-2) 45%, transparent); box-shadow:0 6px 22px rgba(15,76,129,.28)}
     .cta:hover, .cta:focus-visible{filter:saturate(112%); box-shadow:0 8px 24px rgba(15,76,129,.35)}
+    .desktop-cta{margin-left:12px}
+    .mobile-cta{display:none}
+    .menu-toggle{display:none; align-items:center; justify-content:center; width:42px; height:42px; border-radius:12px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 40%, transparent); color:var(--fg); cursor:pointer; transition:background .2s ease}
+    .menu-toggle:hover{background:color-mix(in srgb, var(--bg) 60%, transparent)}
+    .menu-toggle svg{width:20px; height:20px}
+    .menu-toggle .close-icon{display:none}
+    .nav.menu-open .menu-toggle .menu-icon{display:none}
+    .nav.menu-open .menu-toggle .close-icon{display:inline}
 
     /* Theme toggle */
     .theme-toggle{display:inline-flex; align-items:center; justify-content:center; width:42px; height:42px; margin-right:10px; border-radius:12px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 40%, transparent); color:var(--fg); cursor:pointer}

--- a/media-queries.css
+++ b/media-queries.css
@@ -7,12 +7,21 @@
 
 @media (max-width: 640px){
   header{border-bottom-width:0}
-  .nav{display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:10px 14px; padding:12px 0}
+  .nav{display:grid; grid-template-columns:auto 1fr auto auto; align-items:center; gap:10px 12px; padding:12px 0; --nav-height:72px}
+  .nav.menu-open{z-index:120}
   .brand{font-size:16px}
-  .theme-toggle{margin-right:0; width:36px; height:36px; justify-self:end}
-  .cta{padding:10px 16px; font-size:15px; justify-self:end}
-  nav ul{display:none}
+  .brand{grid-column:1}
+  .theme-toggle{margin-right:0; width:36px; height:36px; justify-self:end; grid-column:3}
+  .menu-toggle{display:inline-flex; width:40px; height:40px; justify-self:end; grid-column:4}
+  .desktop-cta{display:none}
   .nav nav{display:none}
+  .nav.menu-open::before{content:""; position:fixed; inset:0; background:rgba(15,23,42,0.45); backdrop-filter:blur(6px); z-index:100}
+  .nav.menu-open nav{display:flex; flex-direction:column; gap:12px; position:fixed; top:calc(var(--nav-height, 68px) + 16px); left:16px; right:16px; padding:20px 22px; border-radius:18px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 94%, transparent); box-shadow:0 24px 60px rgba(15,23,42,.28); max-height:calc(100vh - var(--nav-height, 68px) - 32px); overflow:auto; z-index:120}
+  .nav.menu-open nav ul{display:flex; flex-direction:column; gap:8px; margin:0; padding:0}
+  .nav.menu-open nav li a{display:block; padding:12px 8px; border-radius:12px; font-weight:600; border:1px solid transparent; background:color-mix(in srgb, var(--bg) 60%, transparent); text-align:center}
+  .nav.menu-open nav li a:hover,
+  .nav.menu-open nav li a:focus-visible{background:color-mix(in srgb, var(--accent-2) 18%, transparent); border-color:color-mix(in srgb, var(--accent) 24%, transparent); outline:none}
+  .nav.menu-open .mobile-cta{display:inline-flex; width:100%; justify-content:center; font-size:16px; padding:14px 20px}
   .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
   .form-row{grid-template-columns:1fr}
   .hero-cta{flex-direction:column}
@@ -26,14 +35,15 @@
 /* Hero size overrides (mobile) */
 @media (max-width: 640px){
   .hero{min-height:auto}
-  .hero .container{padding:56px 20px}
+  .hero .container{padding:40px 20px}
   .network-card{min-height:320px}
   .cta{width:max-content}
 }
 @media (max-width: 480px){
-  .nav{grid-template-columns:auto auto; grid-template-rows:auto auto}
-  .cta{grid-column:1 / -1; justify-self:stretch; width:100%; text-align:center}
-  .hero .container{padding:48px 16px}
+  .nav{grid-template-columns:auto 1fr auto auto}
+  .theme-toggle{width:34px; height:34px}
+  .menu-toggle{width:38px; height:38px}
+  .hero .container{padding:32px 16px}
   .ring{width:96px; height:96px}
   .lead{font-size:16px}
   .btn-lg{font-size:16px; padding:14px 20px}


### PR DESCRIPTION
## Summary
- add a hamburger-triggered mobile navigation drawer with CTA links
- style the header for small screens and hide the desktop CTA while the menu is open
- reduce hero padding on phones and lock body scroll when the menu is expanded

## Testing
- Manual verification in a browser

------
https://chatgpt.com/codex/tasks/task_e_68d82d09016083238a1edcec113a0797