### PR TITLE
Improve mobile header layout and default light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,11 @@
     (function(){
       try{
         var stored = localStorage.getItem('theme');
-        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (stored === 'dark' || (stored === null && prefersDark)) document.documentElement.setAttribute('data-theme','dark');
-        else if (stored === 'light') document.documentElement.setAttribute('data-theme','light');
+        if (stored === 'dark'){
+          document.documentElement.setAttribute('data-theme','dark');
+        }else{
+          document.documentElement.setAttribute('data-theme','light');
+        }
       }catch(e){}
     })();
   </script>
@@ -48,7 +50,6 @@
           <li><a href="#projects">Projects</a></li>
           <li><a href="#contact">Contact</a></li>
         </ul>
-        <a class="cta mobile-cta" href="#contact">Work with us</a>
       </nav>
       <button class="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false">
         <svg class="sun" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="1.8"/><path d="M12 2v3M12 19v3M4.6 4.6l2.1 2.1M17.3 17.3l2.1 2.1M2 12h3M19 12h3M4.6 19.4l2.1-2.1M17.3 6.7l2.1-2.1" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>

--- a/media-queries.css
+++ b/media-queries.css
@@ -7,12 +7,12 @@
 
 @media (max-width: 640px){
   header{border-bottom-width:0}
-  .nav{display:grid; grid-template-columns:auto 1fr auto auto; align-items:center; gap:10px 12px; padding:12px 0; --nav-height:72px}
+  .nav{display:grid; grid-template-columns:1fr auto auto; align-items:center; gap:10px; padding:12px 0; --nav-height:72px}
   .nav.menu-open{z-index:120}
   .brand{font-size:16px}
   .brand{grid-column:1}
-  .theme-toggle{margin-right:0; width:36px; height:36px; justify-self:end; grid-column:3}
-  .menu-toggle{display:inline-flex; width:40px; height:40px; justify-self:end; grid-column:4}
+  .theme-toggle{margin-right:0; width:36px; height:36px; justify-self:end; grid-column:2}
+  .menu-toggle{display:inline-flex; width:40px; height:40px; justify-self:end; grid-column:3}
   .desktop-cta{display:none}
   .nav nav{display:none}
   .nav.menu-open::before{content:""; position:fixed; inset:0; background:rgba(15,23,42,0.45); backdrop-filter:blur(6px); z-index:100}
@@ -21,7 +21,6 @@
   .nav.menu-open nav li a{display:block; padding:12px 8px; border-radius:12px; font-weight:600; border:1px solid transparent; background:color-mix(in srgb, var(--bg) 60%, transparent); text-align:center}
   .nav.menu-open nav li a:hover,
   .nav.menu-open nav li a:focus-visible{background:color-mix(in srgb, var(--accent-2) 18%, transparent); border-color:color-mix(in srgb, var(--accent) 24%, transparent); outline:none}
-  .nav.menu-open .mobile-cta{display:inline-flex; width:100%; justify-content:center; font-size:16px; padding:14px 20px}
   .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
   .form-row{grid-template-columns:1fr}
   .hero-cta{flex-direction:column}
@@ -40,7 +39,7 @@
   .cta{width:max-content}
 }
 @media (max-width: 480px){
-  .nav{grid-template-columns:auto 1fr auto auto}
+  .nav{grid-template-columns:1fr auto auto}
   .theme-toggle{width:34px; height:34px}
   .menu-toggle{width:38px; height:38px}
   .hero .container{padding:32px 16px}


### PR DESCRIPTION
## Summary
- ensure the mobile header keeps the logo, theme toggle, and hamburger in a single row
- remove the redundant "Work with us" CTA from the hamburger navigation on small screens
- force the site to load the light theme by default unless the user has explicitly chosen dark mode

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8304c94d08323814a6842f7e4fcaa