### PR TITLE
Fix mobile header spacing and full-screen menu

### DIFF
--- a/main.css
+++ b/main.css
@@ -42,7 +42,7 @@
 
     /* Header */
     header{position:sticky; top:0; z-index:50; backdrop-filter:saturate(140%) blur(10px); background:color-mix(in srgb, var(--bg) 70%, transparent); border-bottom:1px solid var(--border)}
-    .nav{display:flex; align-items:center; justify-content:space-between; padding:14px 0; position:relative}
+    .nav{display:flex; align-items:center; justify-content:space-between; gap:18px; padding:14px clamp(12px, 4vw, 24px); position:relative}
     .brand{display:flex; align-items:center; gap:12px; font-weight:700; letter-spacing:.2px; font-size:18px; color:var(--accent)}
     .brand .logo{width:40px; height:auto; display:block; filter:drop-shadow(0 6px 18px rgba(15,76,129,.25))}
     :root[data-theme="dark"] .brand{color:var(--accent-2)}

--- a/media-queries.css
+++ b/media-queries.css
@@ -7,18 +7,17 @@
 
 @media (max-width: 640px){
   header{border-bottom-width:0}
-  .nav{display:grid; grid-template-columns:1fr auto auto; align-items:center; gap:10px; padding:12px 0; --nav-height:72px}
+  .nav{display:flex; align-items:center; gap:12px; justify-content:flex-start; padding:12px clamp(18px, 6vw, 30px); --nav-height:72px}
   .nav.menu-open{z-index:120}
-  .brand{font-size:16px}
-  .brand{grid-column:1}
-  .theme-toggle{margin-right:0; width:36px; height:36px; justify-self:end; grid-column:2}
-  .menu-toggle{display:inline-flex; width:40px; height:40px; justify-self:end; grid-column:3}
+  .brand{font-size:16px; flex:1; min-width:0}
+  .theme-toggle{margin-right:0; margin-left:auto; width:36px; height:36px}
+  .menu-toggle{display:inline-flex; width:40px; height:40px}
   .desktop-cta{display:none}
   .nav nav{display:none}
   .nav.menu-open::before{content:""; position:fixed; inset:0; background:rgba(15,23,42,0.45); backdrop-filter:blur(6px); z-index:100}
-  .nav.menu-open nav{display:flex; flex-direction:column; gap:12px; position:fixed; top:calc(var(--nav-height, 68px) + 16px); left:16px; right:16px; padding:20px 22px; border-radius:18px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 94%, transparent); box-shadow:0 24px 60px rgba(15,23,42,.28); max-height:calc(100vh - var(--nav-height, 68px) - 32px); overflow:auto; z-index:120}
-  .nav.menu-open nav ul{display:flex; flex-direction:column; gap:8px; margin:0; padding:0}
-  .nav.menu-open nav li a{display:block; padding:12px 8px; border-radius:12px; font-weight:600; border:1px solid transparent; background:color-mix(in srgb, var(--bg) 60%, transparent); text-align:center}
+  .nav.menu-open nav{display:flex; flex-direction:column; gap:16px; position:fixed; inset:0; padding:calc(var(--nav-height, 68px) + 28px) clamp(28px, 9vw, 56px) 36px; border-radius:0; border:none; background:color-mix(in srgb, var(--bg) 96%, transparent); box-shadow:none; max-height:none; overflow:auto; z-index:130; align-items:flex-start}
+  .nav.menu-open nav ul{display:flex; flex-direction:column; gap:12px; margin:0; padding:0; width:100%}
+  .nav.menu-open nav li a{display:block; width:100%; padding:14px 10px; border-radius:14px; font-weight:600; border:1px solid transparent; background:color-mix(in srgb, var(--bg) 62%, transparent); text-align:left}
   .nav.menu-open nav li a:hover,
   .nav.menu-open nav li a:focus-visible{background:color-mix(in srgb, var(--accent-2) 18%, transparent); border-color:color-mix(in srgb, var(--accent) 24%, transparent); outline:none}
   .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
@@ -39,7 +38,7 @@
   .cta{width:max-content}
 }
 @media (max-width: 480px){
-  .nav{grid-template-columns:1fr auto auto}
+  .nav{padding:10px clamp(22px, 8vw, 34px); gap:10px}
   .theme-toggle{width:34px; height:34px}
   .menu-toggle{width:38px; height:38px}
   .hero .container{padding:32px 16px}


### PR DESCRIPTION
## Summary
- add responsive padding so the logo, theme toggle, and hamburger icon have consistent breathing room
- switch the mobile nav layout to flex so the theme toggle stays on the first row and expand the hamburger drawer to a full-screen overlay

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68d83dfc510883238512c598a06376ac