### PR TITLE
Adjust hero spacing on mobile

### DIFF
--- a/media-queries.css
+++ b/media-queries.css
@@ -33,7 +33,7 @@
 /* Hero size overrides (mobile) */
 @media (max-width: 640px){
   .hero{min-height:auto}
-  .hero .container{padding:40px 20px}
+  .hero .container{padding:24px 20px 44px}
   .network-card{min-height:320px}
   .cta{width:max-content}
 }
@@ -41,7 +41,7 @@
   .nav{padding:10px clamp(22px, 8vw, 34px); gap:10px}
   .theme-toggle{width:34px; height:34px}
   .menu-toggle{width:38px; height:38px}
-  .hero .container{padding:32px 16px}
+  .hero .container{padding:20px 16px 40px}
   .ring{width:96px; height:96px}
   .lead{font-size:16px}
   .btn-lg{font-size:16px; padding:14px 20px}


### PR DESCRIPTION
## Summary
- reduce the hero section's top padding on small screens to tighten the space beneath the header
- tweak very small screen spacing to maintain comfortable bottom padding while minimizing blank space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8455628d08323862ff7181db66d46