### PR TITLE
Update mobile navigation drawer background and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,10 @@
       <nav id="primary-nav">
         <div class="mobile-menu-header" aria-hidden="true">
           <span class="eyebrow">Navigation</span>
-          <p>Jump to the section you need or reach out to start a project.</p>
         </div>
+        <button class="drawer-close" type="button" aria-label="Close navigation">
+          <span aria-hidden="true">&times;</span>
+        </button>
         <ul>
           <li><a href="#about">About</a></li>
           <li><a href="#projects">Projects</a></li>
@@ -61,7 +63,6 @@
         </div>
         <div class="mobile-menu-meta">
           <a class="menu-link" href="mailto:hello@uplora.com">hello@uplora.com</a>
-          <a class="menu-link" href="tel:+15555551234">+1 (555) 555‑1234</a>
         </div>
       </nav>
       <button class="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false">
@@ -446,6 +447,7 @@
     var menu = document.getElementById(menuToggle.getAttribute('aria-controls'));
     if(!menu) return;
     var firstLink = menu.querySelector('a');
+    var closeButton = menu.querySelector('.drawer-close');
     var previousOverflow = '';
 
     function closeMenu(){
@@ -469,6 +471,13 @@
       var isOpen = navContainer.classList.contains('menu-open');
       if(isOpen) closeMenu(); else openMenu();
     });
+
+    if(closeButton){
+      closeButton.addEventListener('click', function(){
+        closeMenu();
+        menuToggle.focus();
+      });
+    }
 
     menu.addEventListener('click', function(evt){
       var target = evt.target;

--- a/main.css
+++ b/main.css
@@ -68,6 +68,9 @@
     .mobile-menu-meta .menu-link:hover,
     .mobile-menu-meta .menu-link:focus-visible{color:var(--accent-2)}
     .mobile-menu-divider{display:none; width:100%; height:1px; background:linear-gradient(90deg, transparent, color-mix(in srgb, var(--border) 90%, transparent) 20%, color-mix(in srgb, var(--border) 90%, transparent) 80%, transparent)}
+    .drawer-close{display:none; align-items:center; justify-content:center; padding:6px; border-radius:10px; border:1px solid transparent; background:transparent; color:var(--muted); font-size:26px; line-height:1; cursor:pointer; transition:color .2s ease, background .2s ease}
+    .drawer-close:hover,
+    .drawer-close:focus-visible{background:color-mix(in srgb, var(--bg) 70%, transparent); color:var(--fg); outline:none}
     .menu-toggle{display:none; align-items:center; justify-content:center; width:42px; height:42px; border-radius:12px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 40%, transparent); color:var(--fg); cursor:pointer; transition:background .2s ease}
     .menu-toggle:hover{background:color-mix(in srgb, var(--bg) 60%, transparent)}
     .menu-toggle svg{width:20px; height:20px}

--- a/media-queries.css
+++ b/media-queries.css
@@ -15,7 +15,7 @@
   .desktop-cta{display:none}
   .nav nav{display:none}
   .nav.menu-open::before{content:""; position:fixed; inset:0; background:rgba(15,23,42,0.45); backdrop-filter:blur(6px); z-index:100}
-  .nav.menu-open nav{display:flex; flex-direction:column; gap:18px; position:fixed; inset:0; width:100%; min-height:100vh; padding:calc(var(--nav-height, 68px) + 28px + env(safe-area-inset-top, 0px)) clamp(28px, 9vw, 56px) max(42px, env(safe-area-inset-bottom, 0px) + 24px); border-radius:0; border:none; background:color-mix(in srgb, var(--bg) 94%, transparent); box-shadow:none; max-height:none; overflow:auto; z-index:130; align-items:flex-start; animation:drawer-fade .18s ease-out, drawer-slide .26s var(--ease-smooth) both}
+  .nav.menu-open nav{display:flex; flex-direction:column; gap:18px; position:fixed; inset:0; width:100%; min-height:100vh; padding:calc(var(--nav-height, 68px) + 28px + env(safe-area-inset-top, 0px)) clamp(28px, 9vw, 56px) max(42px, env(safe-area-inset-bottom, 0px) + 24px); border-radius:0; border:none; background:var(--bg); box-shadow:none; max-height:none; overflow:auto; z-index:130; align-items:flex-start; animation:drawer-fade .18s ease-out, drawer-slide .26s var(--ease-smooth) both}
   .nav.menu-open nav ul{display:flex; flex-direction:column; gap:12px; margin:0; padding:0; width:100%}
   .nav.menu-open nav li a{display:block; width:100%; padding:16px 14px; border-radius:16px; font-weight:600; border:1px solid transparent; background:color-mix(in srgb, var(--bg) 62%, transparent); text-align:left; box-shadow:0 8px 24px rgba(15,23,42,0.08)}
   .nav.menu-open nav li a:hover,
@@ -30,6 +30,9 @@
   .nav.menu-open nav .mobile-menu-meta .menu-link{font-size:15px}
   .nav.menu-open nav .mobile-menu-divider{display:block}
   .nav.menu-open nav .mobile-menu-meta .menu-link svg{width:16px; height:16px}
+  .nav.menu-open nav .drawer-close{display:inline-flex; align-self:flex-end; margin:-8px -8px 0 0; border-color:color-mix(in srgb, var(--border) 80%, transparent); color:var(--muted)}
+  .nav.menu-open nav .drawer-close:hover,
+  .nav.menu-open nav .drawer-close:focus-visible{border-color:color-mix(in srgb, var(--accent) 30%, transparent)}
   .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
   .form-row{grid-template-columns:1fr}
   .hero-cta{flex-direction:column}


### PR DESCRIPTION
## Summary
- make the mobile navigation drawer background opaque to hide page content behind it
- add an explicit close button and remove the phone number and description text from the drawer
- hook the new close control into the existing menu toggle script for accessibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d84c54881483239d50cd40b9f6feaa