### PR TITLE
Adjust mobile navigation close button layout

### DIFF
--- a/main.css
+++ b/main.css
@@ -68,9 +68,9 @@
     .mobile-menu-meta .menu-link:hover,
     .mobile-menu-meta .menu-link:focus-visible{color:var(--accent-2)}
     .mobile-menu-divider{display:none; width:100%; height:1px; background:linear-gradient(90deg, transparent, color-mix(in srgb, var(--border) 90%, transparent) 20%, color-mix(in srgb, var(--border) 90%, transparent) 80%, transparent)}
-    .drawer-close{display:none; align-items:center; justify-content:center; padding:6px; border-radius:10px; border:1px solid transparent; background:transparent; color:var(--muted); font-size:26px; line-height:1; cursor:pointer; transition:color .2s ease, background .2s ease}
+    .drawer-close{display:none; align-items:center; justify-content:center; width:44px; height:44px; border-radius:50%; border:none; background:transparent; color:var(--muted); font-size:32px; line-height:1; cursor:pointer; transition:color .2s ease, background .2s ease, transform .2s ease; position:absolute; top:16px; right:16px}
     .drawer-close:hover,
-    .drawer-close:focus-visible{background:color-mix(in srgb, var(--bg) 70%, transparent); color:var(--fg); outline:none}
+    .drawer-close:focus-visible{background:color-mix(in srgb, var(--bg) 70%, transparent); color:var(--fg); outline:none; transform:scale(1.05)}
     .menu-toggle{display:none; align-items:center; justify-content:center; width:42px; height:42px; border-radius:12px; border:1px solid var(--border); background:color-mix(in srgb, var(--bg) 40%, transparent); color:var(--fg); cursor:pointer; transition:background .2s ease}
     .menu-toggle:hover{background:color-mix(in srgb, var(--bg) 60%, transparent)}
     .menu-toggle svg{width:20px; height:20px}

--- a/media-queries.css
+++ b/media-queries.css
@@ -30,9 +30,9 @@
   .nav.menu-open nav .mobile-menu-meta .menu-link{font-size:15px}
   .nav.menu-open nav .mobile-menu-divider{display:block}
   .nav.menu-open nav .mobile-menu-meta .menu-link svg{width:16px; height:16px}
-  .nav.menu-open nav .drawer-close{display:inline-flex; align-self:flex-end; margin:-8px -8px 0 0; border-color:color-mix(in srgb, var(--border) 80%, transparent); color:var(--muted)}
+  .nav.menu-open nav .drawer-close{display:flex; top:calc(env(safe-area-inset-top, 0px) + 18px); right:clamp(20px, 8vw, 40px); color:var(--muted)}
   .nav.menu-open nav .drawer-close:hover,
-  .nav.menu-open nav .drawer-close:focus-visible{border-color:color-mix(in srgb, var(--accent) 30%, transparent)}
+  .nav.menu-open nav .drawer-close:focus-visible{color:var(--fg)}
   .grid.cols-2, .grid.cols-3, .grid.cols-4{grid-template-columns:1fr}
   .form-row{grid-template-columns:1fr}
   .hero-cta{flex-direction:column}


### PR DESCRIPTION
## Summary
- move the mobile navigation close button to the top-right corner with absolute positioning
- increase the button size and remove the border for a cleaner appearance

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d84f3154308323a597fa4cde7251c7