### PR TITLE
Add lightbox pop-up for carousel images

### DIFF
--- a/carousel.css
+++ b/carousel.css
@@ -48,7 +48,20 @@
 
 
 
-.carousel img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; display:block; }
+.carousel img{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+  cursor:zoom-in;
+}
+
+.carousel figure img:focus-visible{
+  outline:3px solid color-mix(in srgb, var(--ring) 65%, white);
+  outline-offset:2px;
+}
 
 .carousel .nav{
   position:absolute; inset:0; padding:0 16px;
@@ -79,4 +92,92 @@
 
 @media (max-width: 640px){
   :root { --peek: 0px; }
+}
+
+body.is-lightbox-open{overflow:hidden;}
+
+.carousel-lightbox[hidden]{display:none;}
+
+.carousel-lightbox{
+  position:fixed;
+  inset:0;
+  z-index:120;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:32px;
+  background:rgba(9, 14, 28, 0.88);
+  backdrop-filter:blur(6px);
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .18s ease;
+}
+
+.carousel-lightbox.is-active{
+  opacity:1;
+  pointer-events:auto;
+}
+
+.carousel-lightbox__inner{
+  position:relative;
+  max-width:min(1120px, 92vw);
+  width:100%;
+  max-height:90vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.carousel-lightbox__inner img{
+  position:static;
+  width:100%;
+  height:auto;
+  max-height:90vh;
+  object-fit:contain;
+  border-radius:18px;
+  box-shadow:0 25px 60px rgba(2,6,23,.35);
+}
+
+.carousel-lightbox__close{
+  position:absolute;
+  top:14px;
+  right:14px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:42px;
+  height:42px;
+  border-radius:999px;
+  border:1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background:color-mix(in srgb, var(--bg) 75%, transparent);
+  color:var(--fg);
+  cursor:pointer;
+  transition:transform .15s ease, background .15s ease;
+}
+
+.carousel-lightbox__close:hover,
+.carousel-lightbox__close:focus-visible{
+  background:color-mix(in srgb, var(--bg) 92%, transparent);
+  transform:scale(1.05);
+  outline:none;
+}
+
+.carousel-lightbox__close span[aria-hidden="true"]{
+  font-size:26px;
+  line-height:1;
+}
+
+@media (max-width: 640px){
+  .carousel-lightbox{
+    padding:20px;
+  }
+
+  .carousel-lightbox__inner{
+    max-width:96vw;
+  }
+
+  .carousel-lightbox__close{
+    top:10px;
+    right:10px;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -555,6 +555,70 @@
   var carousels = document.querySelectorAll('.carousel');
   if (!carousels.length) return;
 
+  var lightbox      = document.createElement('div');
+  var lightboxInner = document.createElement('div');
+  var lightboxImg   = document.createElement('img');
+  var closeBtn      = document.createElement('button');
+  var activeTrigger = null;
+  var resumeAutoplay = null;
+
+  lightbox.className = 'carousel-lightbox';
+  lightbox.setAttribute('role', 'dialog');
+  lightbox.setAttribute('aria-modal', 'true');
+  lightbox.setAttribute('hidden', '');
+
+  lightboxInner.className = 'carousel-lightbox__inner';
+  lightboxInner.appendChild(lightboxImg);
+
+  closeBtn.type = 'button';
+  closeBtn.className = 'carousel-lightbox__close';
+  closeBtn.innerHTML = '<span aria-hidden="true">&times;</span><span class="visually-hidden">Close image</span>';
+  lightboxInner.appendChild(closeBtn);
+
+  lightbox.appendChild(lightboxInner);
+  document.body.appendChild(lightbox);
+
+  function openLightbox(img, resumeFn) {
+    activeTrigger = img;
+    resumeAutoplay = resumeFn || null;
+    lightboxImg.src = img.currentSrc || img.src;
+    lightboxImg.alt = img.alt || '';
+    lightbox.removeAttribute('hidden');
+    document.body.classList.add('is-lightbox-open');
+    requestAnimationFrame(function () {
+      lightbox.classList.add('is-active');
+      closeBtn.focus();
+    });
+  }
+
+  function closeLightbox() {
+    if (!lightbox.classList.contains('is-active')) return;
+    lightbox.classList.remove('is-active');
+    document.body.classList.remove('is-lightbox-open');
+    if (resumeAutoplay) {
+      resumeAutoplay();
+    }
+    resumeAutoplay = null;
+    if (activeTrigger && activeTrigger.focus) {
+      activeTrigger.focus();
+    }
+    activeTrigger = null;
+  }
+
+  lightbox.addEventListener('transitionend', function (event) {
+    if (event.target !== lightbox || lightbox.classList.contains('is-active')) return;
+    lightbox.setAttribute('hidden', '');
+    lightboxImg.removeAttribute('src');
+  });
+
+  closeBtn.addEventListener('click', function () { closeLightbox(); });
+  lightbox.addEventListener('click', function (event) {
+    if (event.target === lightbox) closeLightbox();
+  });
+  document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape') closeLightbox();
+  });
+
   carousels.forEach(function (c) {
     var track   = c.querySelector('.carousel-track');
     var prevBtn = c.querySelector('.prev');
@@ -574,6 +638,8 @@
     var idx = 1; // start on first REAL slide
     var timer = null, inView = true;
     var dragging = false, x0 = 0;
+    var pointerStartImg = null;
+    var pointerType = '';
 
     function marginLeft() {
       var m = window.getComputedStyle(slides[0]).marginLeft;
@@ -638,9 +704,36 @@
     });
 
     // Swipe
-    track.addEventListener('pointerdown', function (e) { dragging = true; x0 = e.clientX; if (track.setPointerCapture) track.setPointerCapture(e.pointerId); stop(); });
-    track.addEventListener('pointerup',   function (e) { if (!dragging) return; dragging = false; var dx = e.clientX - x0; if (Math.abs(dx) > 40) (dx < 0 ? next() : prev()); play(); });
-    track.addEventListener('pointercancel', function () { dragging = false; play(); });
+    track.addEventListener('pointerdown', function (e) {
+      dragging = true;
+      x0 = e.clientX;
+      pointerType = e.pointerType || '';
+      pointerStartImg = e.target && e.target.closest ? e.target.closest('img') : null;
+      if (track.setPointerCapture) track.setPointerCapture(e.pointerId);
+      stop();
+    });
+    track.addEventListener('pointerup',   function (e) {
+      if (!dragging) return;
+      dragging = false;
+      var dx = e.clientX - x0;
+      var action = '';
+      if (Math.abs(dx) > 40) {
+        action = 'slide';
+        (dx < 0 ? next() : prev());
+      } else if (pointerType === 'mouse' && pointerStartImg) {
+        action = 'click';
+        pointerStartImg.click();
+      }
+      if (action !== 'click') play();
+      pointerStartImg = null;
+      pointerType = '';
+    });
+    track.addEventListener('pointercancel', function () {
+      dragging = false;
+      pointerStartImg = null;
+      pointerType = '';
+      play();
+    });
 
     // Pause rules
     c.addEventListener('mouseenter', stop);
@@ -668,6 +761,22 @@
     requestAnimationFrame(function () {
       slideTo(1, false);
       play();
+    });
+
+    var images = track.querySelectorAll('img');
+    images.forEach(function (img) {
+      img.setAttribute('tabindex', '0');
+      img.addEventListener('click', function () {
+        stop();
+        openLightbox(img, play);
+      });
+      img.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          stop();
+          openLightbox(img, play);
+        }
+      });
     });
   });
 })();


### PR DESCRIPTION
## Summary
- add an accessible lightbox dialog that shows carousel images at a larger size
- update carousel styling for focus, cursor, and the lightbox overlay controls
- pause autoplay when opening the lightbox and resume it on close
- ensure desktop pointer interactions trigger the lightbox when not dragging a slide

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d850c5db5483238edf70f7827115d4