### PR TITLE
Adjust hero spacing on mobile

### DIFF
--- a/media-queries.css
+++ b/media-queries.css
@@ -6,6 +6,7 @@
 }
 
 @media (max-width: 640px){
+  .hero{padding-top:0; border-top:0}
   header{border-bottom-width:0}
   .nav{display:flex; align-items:center; gap:12px; justify-content:flex-start; padding:12px clamp(18px, 6vw, 30px); --nav-height:72px}
   .nav.menu-open{position:fixed; inset:0; width:100%; height:100vh; max-width:none; margin:0; padding:12px clamp(18px, 6vw, 30px); align-items:flex-start; z-index:120}


### PR DESCRIPTION
## Summary
- remove the extra top padding/border on the hero section when viewed on small screens so the content aligns directly under the header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d97bee69b08323849b0322749041c7