### PR TITLE
Make mobile header background transparent

### DIFF
--- a/media-queries.css
+++ b/media-queries.css
@@ -7,7 +7,7 @@
 
 @media (max-width: 640px){
   .hero{padding-top:0; border-top:0}
-  header{border-bottom-width:0}
+  header{border-bottom-width:0; background:transparent}
   .nav{display:flex; align-items:center; gap:12px; justify-content:flex-start; padding:12px clamp(18px, 6vw, 30px); --nav-height:72px}
   .nav.menu-open{position:fixed; inset:0; width:100%; height:100vh; max-width:none; margin:0; padding:12px clamp(18px, 6vw, 30px); align-items:flex-start; z-index:120}
   .brand{font-size:16px; flex:1; min-width:0}


### PR DESCRIPTION
## Summary
- remove the mobile breakpoint header background so the sticky header appears translucent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d980a91bd48323aeb2029fb4e85718