### PR TITLE
Set dark theme as default and improve pillar icon contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Uplora — Software Engineering Studio</title>
   <meta name="description" content="Uplora designs and builds secure, high‑quality web and software products. See our work and contact us." />
-  <meta name="color-scheme" content="light dark">
+  <meta name="color-scheme" content="dark light">
   <script>
     // Set initial theme as early as possible to avoid flash
     (function(){
       try{
         var stored = localStorage.getItem('theme');
-        if (stored === 'dark'){
-          document.documentElement.setAttribute('data-theme','dark');
-        }else{
-          document.documentElement.setAttribute('data-theme','light');
-        }
+        var theme = stored === 'light' || stored === 'dark' ? stored : 'dark';
+        document.documentElement.setAttribute('data-theme', theme);
       }catch(e){}
     })();
   </script>
@@ -116,7 +113,7 @@
         <div class="pillar reveal up">
           <div class="ring"><div class="inner" aria-hidden="true">
             <!-- Layers icon (filled) -->
-            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="#0f172a">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
               <rect x="7" y="7" width="10" height="10" rx="2"/>
               <rect x="4" y="4" width="10" height="10" rx="2" opacity=".55"/>
             </svg>
@@ -127,7 +124,7 @@
         <div class="pillar reveal up">
           <div class="ring"><div class="inner" aria-hidden="true">
             <!-- Team/users icon (filled) -->
-            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="#0f172a">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
               <circle cx="8" cy="9" r="2.6"/>
               <rect x="5" y="13" width="6" height="5" rx="2"/>
               <circle cx="16" cy="10" r="2.3" opacity=".7"/>
@@ -140,7 +137,7 @@
         <div class="pillar reveal up">
           <div class="ring"><div class="inner" aria-hidden="true">
             <!-- Bar chart icon (filled) -->
-            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="#0f172a">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
               <rect x="4" y="12" width="4" height="6" rx="1"/>
               <rect x="10" y="8" width="4" height="10" rx="1" opacity=".85"/>
               <rect x="16" y="5" width="4" height="13" rx="1" opacity=".7"/>
@@ -152,8 +149,8 @@
         <div class="pillar reveal up">
           <div class="ring"><div class="inner" aria-hidden="true">
             <!-- Shield check icon (filled) -->
-            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M12 3l7 3v4c0 4.4-2.9 7.5-7 9-4.1-1.5-7-4.6-7-9V6l7-3z" fill="#0f172a"/>
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true" fill="none">
+              <path d="M12 3l7 3v4c0 4.4-2.9 7.5-7 9-4.1-1.5-7-4.6-7-9V6l7-3z" fill="currentColor"/>
               <path d="M9.2 12.6l1.9 1.9 3.9-3.9" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </div></div>

--- a/main.css
+++ b/main.css
@@ -8,6 +8,7 @@
       --card: #ffffff;
       --border: #dbe4f0;
       --ring: #58b0ea;
+      --pillar-icon: #0f172a;
       --maxw: 1200px;
       --radius: 16px;
       --shadow: 0 10px 30px rgba(2,6,23,.08);
@@ -17,16 +18,16 @@
     @media (prefers-color-scheme: dark){
       :root:not([data-theme]){
         --bg:#0b1220; --bg-soft:#0e1a2b; --fg:#e6eaf5; --muted:#a0acc2; --card:#0f172a;
-        --border:rgba(88,176,234,.3); --ring:#2a9de4; --shadow:0 10px 30px rgba(0,0,0,.5);
+        --border:rgba(88,176,234,.3); --ring:#2a9de4; --pillar-icon:#e6eaf5; --shadow:0 10px 30px rgba(0,0,0,.5);
       }
     }
     :root[data-theme="dark"]{
       --bg:#0b1220; --bg-soft:#0e1a2b; --fg:#e6eaf5; --muted:#a0acc2; --card:#0f172a;
-      --border:rgba(88,176,234,.3); --ring:#2a9de4; --shadow:0 10px 30px rgba(0,0,0,.5);
+      --border:rgba(88,176,234,.3); --ring:#2a9de4; --pillar-icon:#e6eaf5; --shadow:0 10px 30px rgba(0,0,0,.5);
     }
     :root[data-theme="light"]{
       --bg:#ffffff; --bg-soft:#f3f7fb; --fg:#0f172a; --muted:#4b5563; --card:#ffffff;
-      --border:#dbe4f0; --ring:#58b0ea; --shadow:0 10px 30px rgba(2,6,23,.08);
+      --border:#dbe4f0; --ring:#58b0ea; --pillar-icon:#0f172a; --shadow:0 10px 30px rgba(2,6,23,.08);
     }
     *{box-sizing:border-box}
     html{scroll-behavior:smooth}
@@ -212,6 +213,7 @@
     .pillar{text-align:center; padding:8px}
     .ring{position:relative; width:140px; height:140px; border-radius:999px; padding:4px; margin:0 auto 12px; background:conic-gradient(from 200deg, var(--accent), color-mix(in srgb, var(--accent-2) 70%, white), var(--accent), var(--accent)); transition:filter .3s ease, transform .25s ease}
     .ring .inner{display:flex; align-items:center; justify-content:center; width:100%; height:100%; border-radius:inherit; background:var(--card); box-shadow:0 10px 24px rgba(15,76,129,.08)}
+    .ring .inner svg{color:var(--pillar-icon)}
     /* halo on hover */
     .ring::after{content:""; position:absolute; inset:-10px; border-radius:inherit; pointer-events:none; background:radial-gradient(closest-side, rgba(15,76,129,.12), rgba(42,157,228,.12) 45%, transparent 70%); opacity:0; transform:scale(.96); transition:opacity .35s var(--ease-smooth), transform .35s var(--ease-smooth)}
     .pillar:hover .ring::after{opacity:1; transform:scale(1.02)}


### PR DESCRIPTION
## Summary
- default the site to dark mode when no user preference is stored
- adjust the about pillar SVGs to inherit theme-aware colors for better contrast in dark mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d995cfb9fc8323b12176539e3bd57e