### PR TITLE
Add maintenance blackout overlay to temporarily hide site content

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <link rel="stylesheet" href="media-queries.css" />
 
 </head>
-<body>
+<body class="maintenance-mode">
   <!-- Header -->
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">

--- a/main.css
+++ b/main.css
@@ -227,3 +227,7 @@
 
     /* A11y helpers */
     .visually-hidden{position:absolute !important; height:1px; width:1px; overflow:hidden; clip:rect(1px,1px,1px,1px); white-space:nowrap}
+
+    body.maintenance-mode{overflow:hidden}
+    body.maintenance-mode *{visibility:hidden}
+    body.maintenance-mode::before{content:""; position:fixed; inset:0; background:#000; z-index:9999; visibility:visible}


### PR DESCRIPTION
## Summary
- add a maintenance-mode class to the page body to enable a full-screen blackout state
- define CSS that hides all content and displays a fixed black overlay for maintenance windows

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d9b575d374832392344b2028b66b97